### PR TITLE
Gallery/Modal doesn't require "photo-gallery" parent

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
           </div>
         </div>
       </section>
-      <section class="events">
+      <section class="events photo-gallery">
         <div class="event" href="lesswrong-software.html">
-          <img class="event-photo" src="./public/stuart-park-square.jpg"/>
+          <img class="event-photo photo-gallery-image" src="./public/stuart-park-square.jpg"/>
           <div>
             <h3>
               Team Retreats
@@ -69,7 +69,7 @@
           </div>
         </div>
         <div class="event" href="s-process-developer.html">
-          <img class="event-photo" src="public/presentation-square.jpg"/>
+          <img class="event-photo photo-gallery-image" src="public/presentation-square.jpg"/>
           <div>
             <h3>Conferences</h3>
             <h4>
@@ -81,7 +81,7 @@
           </div>
         </div>
         <div class="event" href="s-process-developer.html">
-          <img class="event-photo" src="public/bedroom-1-square.jpg"/>
+          <img class="event-photo photo-gallery-image" src="public/bedroom-1-square.jpg"/>
           <div>
             <h3>Lodging</h3>
             <h4>
@@ -93,7 +93,7 @@
           </div>
         </div>
         <div class="event">
-          <img class="event-photo" src="public/crowd-stuart-park-square.jpg"/>
+          <img class="event-photo photo-gallery-image" src="public/crowd-stuart-park-square.jpg"/>
           <div>
             <h3>Parties</h3>
             <h4>

--- a/modal.js
+++ b/modal.js
@@ -6,9 +6,6 @@ var closeButton = document.getElementsByClassName("close")[0];
 var nextButton = document.getElementById("next-button");
 var prevButton = document.getElementById("prev-button");
 
-// Get the gallery container
-var galleryRows = document.getElementsByClassName("photo-gallery");
-
 // Get all the image links in the gallery
 var imageLinks = Array.from(document.getElementsByClassName("photo-gallery-image"))
 

--- a/modal.js
+++ b/modal.js
@@ -11,7 +11,6 @@ var galleryRows = document.getElementsByClassName("photo-gallery");
 
 // Get all the image links in the gallery
 var imageLinks = Array.from(document.getElementsByClassName("photo-gallery-image"))
-console.log(imageLinks)
 
 // Variables to track the currently displayed image and total number of images
 var currentImageIndex = 0;

--- a/modal.js
+++ b/modal.js
@@ -10,9 +10,8 @@ var prevButton = document.getElementById("prev-button");
 var galleryRows = document.getElementsByClassName("photo-gallery");
 
 // Get all the image links in the gallery
-var imageLinks = Array.from(galleryRows).flatMap((row) =>
-  Array.from(row.querySelectorAll(".photo-gallery-image"))
-);
+var imageLinks = Array.from(document.getElementsByClassName("photo-gallery-image"))
+console.log(imageLinks)
 
 // Variables to track the currently displayed image and total number of images
 var currentImageIndex = 0;


### PR DESCRIPTION
I wanted to make some additional images into gallery-modal images. In a previous commit I had renamed the class for identifying a gallery image and gallery-container to "photo-gallery-image" and "photo-gallery", so it had not other stylistic content. In this PR I remove the "photo-gallery" from the modal requirements because I didn't see what purpose it was serving, and I think I prefer all images to exist in the same gallery.

But, checking in with Robert first